### PR TITLE
HTTP and CoAP

### DIFF
--- a/cddl/coap-protocol-map.cddl
+++ b/cddl/coap-protocol-map.cddl
@@ -1,0 +1,8 @@
+$$SDF-EXTENSION-DATA //= coap-protocol-map
+
+coap-protocol-map = {
+  method: "GET" / "POST" / "PUT" / "DELETE"
+  uri: text
+  ? query: {text => text}
+  ? options: {text => text}
+}

--- a/cddl/http-protocol-map.cddl
+++ b/cddl/http-protocol-map.cddl
@@ -1,0 +1,9 @@
+$$SDF-EXTENSION-DATA //= http-protocol-map
+
+http-protocol-map = {
+  method: "GET" / "POST" / "PUT" / "DELETE"
+  path: text
+  ? query: {text => text}
+  ? headers: {text => text}
+  ? body: text
+}

--- a/cddl/openapi-protocol-map.cddl
+++ b/cddl/openapi-protocol-map.cddl
@@ -1,0 +1,6 @@
+$$SDF-EXTENSION-DATA //= openapi-protocol-map
+
+openapi-protocol-map = {
+  operationRef: text
+  $ref: text
+}

--- a/draft-mohan-asdf-sdf-protocol-mapping.md
+++ b/draft-mohan-asdf-sdf-protocol-mapping.md
@@ -383,7 +383,7 @@ The above SDF Protocol Mapping will be resolved to the following HTTP request: `
 ### CoAP
 
 The CoAP protocol mapping allows SDF models to specify how affordances should be
-accessed using the CoAP protocol. The mapping includes details such as method,
+accessed using CoAP. The mapping includes details such as method,
 URI, as well as optional query string and options.
 
 ~~~ cddl

--- a/draft-mohan-asdf-sdf-protocol-mapping.md
+++ b/draft-mohan-asdf-sdf-protocol-mapping.md
@@ -323,9 +323,20 @@ For example, a Zigbee protocol mapping for a temperature property might look lik
 
 ## IP based Protocol Mapping
 
-The protocol mapping mechanism can potentially also be used for IP-based protocols
-such as HTTP or CoAP. An example of a protocol mapping for a property using HTTP
-might look like:
+The protocol mapping mechanism can also be used for IP-based protocols
+such as HTTP or CoAP.
+
+### OpenAPI Protocol Mapping Structure
+
+In the case of HTTP, SDF protocol mappings towards an SDF quality MAY be
+expressed by directly pointing to OpenAPI schema and/or component.
+
+~~~ cddl
+{::include cddl/openapi-protocol-map.cddl}
+~~~
+{: #apimap1 title="CDDL definition for HTTP OpenAPI Protocol Mapping for properties and actions"}
+
+An example of a protocol mapping for a property using HTTP might look like:
 
 ~~~ json
 =============== NOTE: '\' line wrapping per RFC 8792 ================

--- a/draft-mohan-asdf-sdf-protocol-mapping.md
+++ b/draft-mohan-asdf-sdf-protocol-mapping.md
@@ -127,8 +127,8 @@ sdfProtocolMap
   |        |
   |        +--> HTTP-specific mapping
   +-----> coap
-  |        |
-  |        +--> CoAP-specific mapping
+           |
+           +--> CoAP-specific mapping
 ~~~
 {: #protmap title="Property Mapping"}
 

--- a/draft-mohan-asdf-sdf-protocol-mapping.md
+++ b/draft-mohan-asdf-sdf-protocol-mapping.md
@@ -104,12 +104,13 @@ protocol-specific operation, as implementations of the same affordance will
 differ between protocols. For example, BLE will address a property as a service
 characteristic, while a property in Zigbee is addressed as an attribute in a
 cluster of an endpoint. Again, HTTP is addressed by a method, an endpoint path,
-an optional query string, optional headers, and an optional body.
+an optional query string, optional headers, and an optional body. Finally, CoAP
+is addressed by a method, a URI, an optional query string and options set.
 
 A protocol mapping object is a JSON object identified by the `sdfProtocolMap`
 keyword. Protocol-specific properties are embedded within this object, organized
-by protocol name, e.g., "ble" or "zigbee" or "http". The protocol name MUST be
-specified in the IANA registry requested in {{iana-prot-map}}.
+by protocol name, e.g., "ble" or "zigbee" or "http" or "coap". The protocol name
+MUST be specified in the IANA registry requested in {{iana-prot-map}}.
 
 ~~~ aasvg
 sdfProtocolMap
@@ -123,8 +124,11 @@ sdfProtocolMap
   |        +--> Zigbee-specific mapping
   |
   +-----> http
-           |
-           +--> HTTP-specific mapping
+  |        |
+  |        +--> HTTP-specific mapping
+  +-----> coap
+  |        |
+  |        +--> CoAP-specific mapping
 ~~~
 {: #protmap title="Property Mapping"}
 
@@ -344,7 +348,7 @@ parameters that are used to access the corresponding SDF affordances.
 ~~~ cddl
 {::include cddl/http-protocol-map.cddl}
 ~~~
-{: #httpmap1 title="CDDL definition for HTTP OpenAPI Protocol Mapping for properties, actions, and events"}
+{: #httpmap1 title="CDDL definition for HTTP Protocol Mapping for properties, actions, and events"}
 
 Where:
 
@@ -373,6 +377,64 @@ For example, a HTTP protocol mapping for a temperature property might look like:
 ~~~
 
 The above SDF Protocol Mapping will be resolved to the following HTTP request: `GET /device/123/temperature/0?unit=celsius`.
+
+### CoAP
+
+The CoAP protocol mapping allows SDF models to specify how affordances should be
+accessed using the CoAP protocol. The mapping includes details such as method,
+URI, as well as optional query string and options.
+
+~~~ cddl
+{::include cddl/coap-protocol-map.cddl}
+~~~
+{: #coapmap1 title="CDDL definition for CoAP Protocol Mapping for properties, actions, and events"}
+
+Where:
+
+- `method` is the method of the CoAP request towards the affordance. Allowed methods are `GET`, `POST`, `PUT`, and `DELETE`.
+- `uri` is the URI that identifies the resource associated to the affordance.
+- `query` is the optional query string expressed as a text map. The key of the map is the name of the query parameter and the value of the map is the value of the query parameter.
+- `options` is the optional set of CoAP options expressed as text map. The key of the map is the name of the option and the value of the map is the value of the option.
+
+For example, a CoAP protocol mapping for a temperature property may look like:
+
+~~~ jsonc
+{
+  "sdfProperty": {
+    "temperature": {
+      "sdfProtocolMap": {
+        "coap": {
+          "method": "GET",
+          "path": "/device/123/temperature/0",
+          "query": {"unit": "celsius"},
+          "options": {"Accept": "application/senml+json"},
+        }
+      }
+    }
+  }
+}
+~~~
+
+The next example shows how to register for notifications with OBSERVE when a
+resource's value gets above 20, e.g., degree Celsius.
+
+~~~ jsonc
+{
+  "sdfProperty": {
+    "temperature": {
+      "sdfProtocolMap": {
+        "coap": {
+          "method": "GET",
+          "path": "/device/123/temperature/0?above=20",
+          "query": {"above": "20", "unit": "celsius"},
+          "options": {"Accept": "application/senml+json",
+                      "Observe": 0},
+        }
+      }
+    }
+  }
+}
+~~~
 
 ### OpenAPI Protocol Mapping Structure
 
@@ -480,6 +542,7 @@ Following protocol mappings are described in this document:
 | ble          | Bluetooth Low Energy (BLE)  | Protocol mapping for BLE devices            | This document   |
 | zigbee       | Zigbee                      | Protocol mapping for Zigbee devices         | This document   |
 | http         | HTTP                        | Protocol mapping for HTTP IP-based devices  | This document   |
+| coap         | CoAP                        | Protocol mapping for CoAP IP-based devices  | This document   |
 {: #protmap-reg title="Protocol Mapping Registry"}
 
 --- back
@@ -494,6 +557,8 @@ Following protocol mappings are described in this document:
 {::include cddl/zigbee-protocol-map.cddl}
 
 {::include cddl/http-protocol-map.cddl}
+
+{::include cddl/coap-protocol-map.cddl}
 ~~~
 
 # Acknowledgments

--- a/draft-mohan-asdf-sdf-protocol-mapping.md
+++ b/draft-mohan-asdf-sdf-protocol-mapping.md
@@ -151,8 +151,7 @@ where-
    protocol.
  - "zigbee" is an object containing properties that are specific to the
    Zigbee protocol.
- - "http" is an object containing properties that are specific to the HTTP
-   protocol.
+ - "http" is an object containing properties that are specific to HTTP.
  - Other protocol mapping objects can be added by creating a new protocol
    object
 

--- a/draft-mohan-asdf-sdf-protocol-mapping.md
+++ b/draft-mohan-asdf-sdf-protocol-mapping.md
@@ -544,7 +544,7 @@ Following protocol mappings are described in this document:
 | ble          | Bluetooth Low Energy (BLE)  | Protocol mapping for BLE devices            | This document   |
 | zigbee       | Zigbee                      | Protocol mapping for Zigbee devices         | This document   |
 | http         | HTTP                        | Protocol mapping for HTTP IP-based devices  | This document   |
-| coap         | CoAP                        | Protocol mapping for CoAP IP-based devices  | This document   |
+| coap         | CoAP                        | Protocol mapping for CoAP-based devices  | This document   |
 {: #protmap-reg title="Protocol Mapping Registry"}
 
 --- back

--- a/draft-mohan-asdf-sdf-protocol-mapping.md
+++ b/draft-mohan-asdf-sdf-protocol-mapping.md
@@ -152,6 +152,7 @@ where-
  - "zigbee" is an object containing properties that are specific to the
    Zigbee protocol.
  - "http" is an object containing properties that are specific to HTTP.
+ - "coap" is an object containing properties that are specific to CoAP.
  - Other protocol mapping objects can be added by creating a new protocol
    object
 

--- a/draft-mohan-asdf-sdf-protocol-mapping.md
+++ b/draft-mohan-asdf-sdf-protocol-mapping.md
@@ -99,16 +99,17 @@ mapping information alongside the protocol-agnostic definitions.
 
 # Structure
 
-Protocol mapping is required to map a protocol-agnostic affordance to
-a protocol-specific operation, as implementations of the same affordance
-will differ between protocols. For example, BLE will address a property
-as a service characteristic, while a property in Zigbee is addressed
-as an attribute in a cluster of an endpoint.
+Protocol mapping is required to map a protocol-agnostic affordance to a
+protocol-specific operation, as implementations of the same affordance will
+differ between protocols. For example, BLE will address a property as a service
+characteristic, while a property in Zigbee is addressed as an attribute in a
+cluster of an endpoint. Again, HTTP is addressed by a method, an endpoint path,
+an optional query string, optional headers, and an optional body.
 
 A protocol mapping object is a JSON object identified by the `sdfProtocolMap`
 keyword. Protocol-specific properties are embedded within this object, organized
-by protocol name, e.g., "ble" or "zigbee". The protocol name MUST be specified
-in the IANA registry requested in {{iana-prot-map}}.
+by protocol name, e.g., "ble" or "zigbee" or "http". The protocol name MUST be
+specified in the IANA registry requested in {{iana-prot-map}}.
 
 ~~~ aasvg
 sdfProtocolMap
@@ -118,19 +119,24 @@ sdfProtocolMap
   |        +--> BLE-specific mapping
   |
   +-----> zigbee
+  |        |
+  |        +--> Zigbee-specific mapping
+  |
+  +-----> http
            |
-           +--> Zigbee-specific mapping
+           +--> HTTP-specific mapping
 ~~~
 {: #protmap title="Property Mapping"}
 
 As shown in {{protmap}}, protocol-specific properties must be embedded in an
-sdfProtocolMap object, for example a "ble" or a "zigbee" object.
+sdfProtocolMap object, for example a "ble" or a "zigbee" or a "http" object.
 
 
 | Attribute |  Type  |          Example                         |
 +-----------+--------+------------------------------------------|
 | ble       | object | an object with BLE-specific attributes   |
 | zigbee    | object | an object with Zigbee-specific attributes|
+| http      | object | an object with HTTP-specific attributes  |
 {: #proobj title="Protocol objects"}
 
 where-
@@ -139,6 +145,8 @@ where-
    protocol.
  - "zigbee" is an object containing properties that are specific to the
    Zigbee protocol.
+ - "http" is an object containing properties that are specific to the HTTP
+   protocol.
  - Other protocol mapping objects can be added by creating a new protocol
    object
 
@@ -471,6 +479,7 @@ Following protocol mappings are described in this document:
 |--------------|-----------------------------|---------------------------------------------|-----------------|
 | ble          | Bluetooth Low Energy (BLE)  | Protocol mapping for BLE devices            | This document   |
 | zigbee       | Zigbee                      | Protocol mapping for Zigbee devices         | This document   |
+| http         | HTTP                        | Protocol mapping for HTTP IP-based devices  | This document   |
 {: #protmap-reg title="Protocol Mapping Registry"}
 
 --- back
@@ -483,6 +492,8 @@ Following protocol mappings are described in this document:
 {::include cddl/ble-event-map.cddl}
 
 {::include cddl/zigbee-protocol-map.cddl}
+
+{::include cddl/http-protocol-map.cddl}
 ~~~
 
 # Acknowledgments

--- a/draft-mohan-asdf-sdf-protocol-mapping.md
+++ b/draft-mohan-asdf-sdf-protocol-mapping.md
@@ -369,7 +369,7 @@ For example, a HTTP protocol mapping for a temperature property might look like:
       "sdfProtocolMap": {
         "http": {
           "method": "GET",
-          "path": "/device/123/temperature/0",
+          "path": "/device/{some_id}/temperature/{some_other_id}?unit=celsius",
           "query": {"unit": "celsius"},
         }
       }

--- a/draft-mohan-asdf-sdf-protocol-mapping.md
+++ b/draft-mohan-asdf-sdf-protocol-mapping.md
@@ -126,6 +126,7 @@ sdfProtocolMap
   +-----> http
   |        |
   |        +--> HTTP-specific mapping
+  |
   +-----> coap
            |
            +--> CoAP-specific mapping
@@ -141,6 +142,7 @@ sdfProtocolMap object, for example a "ble" or a "zigbee" or a "http" object.
 | ble       | object | an object with BLE-specific attributes   |
 | zigbee    | object | an object with Zigbee-specific attributes|
 | http      | object | an object with HTTP-specific attributes  |
+| coap      | object | an object with CoAP-specific attributes  |
 {: #proobj title="Protocol objects"}
 
 where-

--- a/draft-mohan-asdf-sdf-protocol-mapping.md
+++ b/draft-mohan-asdf-sdf-protocol-mapping.md
@@ -326,6 +326,46 @@ For example, a Zigbee protocol mapping for a temperature property might look lik
 The protocol mapping mechanism can also be used for IP-based protocols
 such as HTTP or CoAP.
 
+### HTTP
+
+The HTTP protocol mapping allows SDF models to specify how properties, actions,
+and events should be accessed using the HTTP protocol. The mapping includes
+details such as method, path, optional headers, request body and query
+parameters that are used to access the corresponding SDF affordances.
+
+~~~ cddl
+{::include cddl/http-protocol-map.cddl}
+~~~
+{: #httpmap1 title="CDDL definition for HTTP OpenAPI Protocol Mapping for properties, actions, and events"}
+
+Where:
+
+- `method` is the method of the HTTP request towards the affordance. Allowed methods are `GET`, `POST`, `PUT`, and `DELETE`.
+- `path` is the path targeted by the HTTP request.
+- `query` is the optional query string expressed as a text map. The key of the map is the name of the query parameter and the value of the map is the value of the query parameter.
+- `headers` is the optional set of HTTP headers expressed as text map. The key of the map is the name of the header and the value of the map is the value of the header field.
+- `body` is the optional body of the HTTP request expressed as text.
+
+For example, a HTTP protocol mapping for a temperature property might look like:
+
+~~~ jsonc
+{
+  "sdfProperty": {
+    "temperature": {
+      "sdfProtocolMap": {
+        "http": {
+          "method": "GET",
+          "path": "/device/123/temperature/0",
+          "query": {"unit": "celsius"},
+        }
+      }
+    }
+  }
+}
+~~~
+
+The above SDF Protocol Mapping will be resolved to the following HTTP request: `GET /device/123/temperature/0?unit=celsius`.
+
 ### OpenAPI Protocol Mapping Structure
 
 In the case of HTTP, SDF protocol mappings towards an SDF quality MAY be


### PR DESCRIPTION
# HTTP and CoAP SDF Protocol Mappings

This PR aim is to add SDF Protocol Mappings for HTTP and CoAP. It addresses the issue #5.

CoAP is still missing.

This PR currently features:
- **OpenAPI CDDL and structure change**
- **Draft of HTTP protocol mapping**
